### PR TITLE
refactor: Move menu registry to an event instead

### DIFF
--- a/src/main/java/com/aetherteam/cumulus/Cumulus.java
+++ b/src/main/java/com/aetherteam/cumulus/Cumulus.java
@@ -1,17 +1,13 @@
 package com.aetherteam.cumulus;
 
-import com.aetherteam.cumulus.api.Menu;
 import com.aetherteam.cumulus.api.Menus;
 import com.aetherteam.cumulus.data.generators.CumulusLanguageData;
 import com.mojang.logging.LogUtils;
 import net.minecraft.SharedConstants;
-import net.minecraft.core.Registry;
 import net.minecraft.data.DataGenerator;
 import net.minecraft.data.PackOutput;
 import net.minecraft.data.metadata.PackMetadataGenerator;
 import net.minecraft.network.chat.Component;
-import net.minecraft.resources.ResourceKey;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.PackType;
 import net.minecraft.server.packs.metadata.pack.PackMetadataSection;
 import net.neoforged.api.distmarker.Dist;
@@ -22,9 +18,6 @@ import net.neoforged.fml.config.ModConfig;
 import net.neoforged.neoforge.client.gui.ConfigurationScreen;
 import net.neoforged.neoforge.client.gui.IConfigScreenFactory;
 import net.neoforged.neoforge.data.event.GatherDataEvent;
-import net.neoforged.neoforge.registries.DeferredRegister;
-import net.neoforged.neoforge.registries.NewRegistryEvent;
-import net.neoforged.neoforge.registries.RegistryBuilder;
 import org.slf4j.Logger;
 
 @Mod(Cumulus.MODID)
@@ -32,22 +25,10 @@ public class Cumulus {
     public static final String MODID = "cumulus_menus";
     public static final Logger LOGGER = LogUtils.getLogger();
 
-    public static final ResourceKey<Registry<Menu>> MENU_REGISTRY_KEY = ResourceKey.createRegistryKey(ResourceLocation.fromNamespaceAndPath(Cumulus.MODID, "menu"));
-    public static final Registry<Menu> MENU_REGISTRY = new RegistryBuilder<>(MENU_REGISTRY_KEY).sync(true).create();
-
     public Cumulus(ModContainer mod, IEventBus bus, Dist dist) {
-        bus.addListener(NewRegistryEvent.class, event -> event.register(MENU_REGISTRY));
-        
         if (dist == Dist.CLIENT) {
+            Menus.init();
             bus.addListener(this::dataSetup);
-
-            DeferredRegister<?>[] registers = {
-                    Menus.MENUS,
-            };
-
-            for (DeferredRegister<?> register : registers) {
-                register.register(bus);
-            }
 
             mod.registerConfig(ModConfig.Type.CLIENT, CumulusConfig.CLIENT_SPEC);
 

--- a/src/main/java/com/aetherteam/cumulus/api/Menu.java
+++ b/src/main/java/com/aetherteam/cumulus/api/Menu.java
@@ -1,6 +1,5 @@
 package com.aetherteam.cumulus.api;
 
-import com.aetherteam.cumulus.Cumulus;
 import com.aetherteam.cumulus.mixin.mixins.client.accessor.ScreenAccessor;
 import net.minecraft.client.gui.screens.TitleScreen;
 import net.minecraft.client.renderer.CubeMap;
@@ -11,14 +10,7 @@ import net.minecraft.sounds.Musics;
 
 import java.util.function.BooleanSupplier;
 
-public class Menu {
-    private final ResourceLocation icon;
-    private final Component name;
-    private final TitleScreen screen;
-    private final BooleanSupplier condition;
-    private final Runnable apply;
-    private final Music music;
-    private final CubeMap panorama;
+public record Menu(ResourceLocation icon, Component name, TitleScreen screen, BooleanSupplier condition, Runnable apply, Music music, CubeMap panorama) {
 
     public Menu(ResourceLocation icon, Component name, TitleScreen screen, BooleanSupplier condition) {
         this(icon, name, screen, condition, new Properties());
@@ -28,75 +20,17 @@ public class Menu {
         this(icon, name, screen, condition, properties.apply, properties.music, properties.panorama);
     }
 
-    public Menu(ResourceLocation icon, Component name, TitleScreen screen, BooleanSupplier condition, Runnable apply, Music music, CubeMap panorama) {
-        this.icon = icon;
-        this.name = name;
-        this.screen = screen;
-        this.condition = condition;
-        this.apply = apply;
-        this.music = music;
-        this.panorama = panorama;
-    }
-
-    /**
-     * @return The {@link ResourceLocation} for the icon that this menu has in the {@link com.aetherteam.cumulus.client.gui.screen.MenuSelectionScreen selection screen}.
-     */
-    public ResourceLocation getIcon() {
-        return this.icon;
-    }
-
-    /**
-     * @return The {@link Component} for the name that this menu has in the {@link com.aetherteam.cumulus.client.gui.screen.MenuSelectionScreen selection screen}.
-     */
-    public Component getName() {
-        return this.name;
-    }
-
-    /**
-     * @return The {@link TitleScreen} to display for this menu.
-     */
-    public TitleScreen getScreen() {
-        return this.screen;
-    }
-
-    /**
-     * @return The {@link BooleanSupplier} condition for when this menu should be able to display.
-     */
-    public BooleanSupplier getCondition() {
-        return this.condition;
-    }
-
-    /**
-     * @return {@link Runnable} for a function to run when this menu is applied.
-     */
-    public Runnable getApply() {
-        return this.apply;
-    }
-
-    /**
-     * @return {@link Music} to run in the menu.
-     */
-    public Music getMusic() {
-        return this.music;
-    }
-
-    /**
-     * @return {@link CubeMap} for the menu panorama.
-     */
-    public CubeMap getPanorama() {
-        return this.panorama;
-    }
-
     /**
      * @return The {@link ResourceLocation} of the {@link Menu}'s full registry ID.
      */
     public ResourceLocation getId() {
-        return Cumulus.MENU_REGISTRY.getKey(this);
+        return Menus.getKey(this);
     }
 
     /**
      * @return The {@link String} of the {@link Menu}'s full registry ID, converted from a {@link ResourceLocation} from {@link Menu#getId()}.
      */
+    @Override
     public String toString() {
         return this.getId().toString();
     }
@@ -107,7 +41,7 @@ public class Menu {
         private CubeMap panorama = ScreenAccessor.cumulus$getCubeMap();
 
         /**
-         * @see Menu#getApply()
+         * @see Menu#apply()
          */
         public Properties apply(Runnable apply) {
             this.apply = apply;
@@ -115,7 +49,7 @@ public class Menu {
         }
 
         /**
-         * @see Menu#getMusic()
+         * @see Menu#music()
          */
         public Properties music(Music music) {
             this.music = music;
@@ -123,7 +57,7 @@ public class Menu {
         }
 
         /**
-         * @see Menu#getPanorama()
+         * @see Menu#panorama()
          */
         public Properties panorama(CubeMap panorama) {
             this.panorama = panorama;

--- a/src/main/java/com/aetherteam/cumulus/api/MenuHelper.java
+++ b/src/main/java/com/aetherteam/cumulus/api/MenuHelper.java
@@ -8,9 +8,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.TitleScreen;
 import net.minecraft.client.renderer.PanoramaRenderer;
-import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.sounds.Music;
-import net.neoforged.neoforge.registries.DeferredHolder;
 
 import javax.annotation.Nullable;
 import java.util.Calendar;
@@ -47,11 +45,9 @@ public class MenuHelper {
      * Prepares a menu for application by marking it active if the condition is true.
      * @param menu The {@link Menu} to set active.
      */
-    public void prepareMenu(DeferredHolder<Menu, Menu> menu) {
-        if (menu.getKey() != null && BuiltInRegistries.REGISTRY.get(menu.getKey().registry()) != null) {
-            if (menu.get().getCondition().getAsBoolean()) {
-                this.setActiveMenu(menu.get());
-            }
+    public void prepareMenu(Menu menu) {
+        if (menu.condition().getAsBoolean()) {
+            this.setActiveMenu(menu);
         }
     }
 
@@ -63,18 +59,18 @@ public class MenuHelper {
     @Nullable
     public TitleScreen applyMenu(Menu menu) {
         if (CumulusConfig.CLIENT.enable_menu_api.get()) {
-            TitleScreen screen = this.checkFallbackScreen(menu, menu.getScreen());
+            TitleScreen screen = this.checkFallbackScreen(menu, menu.screen());
             if (this.shouldFade()) {
                 TitleScreenAccessor defaultMenuAccessor = (TitleScreenAccessor) screen;
                 defaultMenuAccessor.cumulus$setFading(true);
                 defaultMenuAccessor.cumulus$setFadeInStart(0L);
             }
-            ScreenAccessor.cumulus$setCubeMap(menu.getPanorama());
-            ScreenAccessor.cumulus$setPanorama(new PanoramaRenderer(menu.getPanorama()));
+            ScreenAccessor.cumulus$setCubeMap(menu.panorama());
+            ScreenAccessor.cumulus$setPanorama(new PanoramaRenderer(menu.panorama()));
             if (this.getLastSplash() != null) {
                 this.migrateSplash(this.getLastSplash(), screen);
             }
-            menu.getApply().run();
+            menu.apply().run();
             return screen;
         }
         return this.getFallbackTitleScreen();
@@ -87,7 +83,7 @@ public class MenuHelper {
      * @return The fallback {@link TitleScreen}.
      */
     private TitleScreen checkFallbackScreen(Menu menu, TitleScreen screen) {
-        if ((screen.getClass() == TitleScreen.class || menu == Menus.MINECRAFT.get()) && this.getFallbackTitleScreen() != null) {
+        if ((screen.getClass() == TitleScreen.class || menu == Menus.MINECRAFT) && this.getFallbackTitleScreen() != null) {
             screen = this.getFallbackTitleScreen();
         }
         return screen;
@@ -97,7 +93,7 @@ public class MenuHelper {
      * Resets the active menu to the default Minecraft menu.
      */
     public void clearActiveMenu() {
-        this.activeMenu = Menus.MINECRAFT.get();
+        this.activeMenu = Menus.MINECRAFT;
     }
 
     /**
@@ -105,7 +101,7 @@ public class MenuHelper {
      */
     @Nullable
     public TitleScreen getActiveScreen() {
-        return this.getActiveMenu() != null ? this.getActiveMenu().getScreen() : null;
+        return this.getActiveMenu() != null ? this.getActiveMenu().screen() : null;
     }
 
     /**
@@ -113,7 +109,7 @@ public class MenuHelper {
      */
     @Nullable
     public Music getActiveMusic() {
-        return this.getActiveMenu() != null ? this.getActiveMenu().getMusic() : null;
+        return this.getActiveMenu() != null ? this.getActiveMenu().music() : null;
     }
 
     /**

--- a/src/main/java/com/aetherteam/cumulus/api/Menus.java
+++ b/src/main/java/com/aetherteam/cumulus/api/Menus.java
@@ -1,44 +1,66 @@
 package com.aetherteam.cumulus.api;
 
-import com.aetherteam.cumulus.Cumulus;
+import com.google.common.collect.ImmutableMap;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.TitleScreen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import net.neoforged.neoforge.registries.DeferredHolder;
-import net.neoforged.neoforge.registries.DeferredRegister;
+import net.neoforged.fml.ModLoader;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.BooleanSupplier;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 public class Menus {
-    public static final DeferredRegister<Menu> MENUS = DeferredRegister.create(Cumulus.MENU_REGISTRY_KEY, Cumulus.MODID);
 
     public static final ResourceLocation MINECRAFT_ICON = ResourceLocation.withDefaultNamespace("textures/block/grass_block_side.png");
     public static final Component MINECRAFT_NAME = Component.translatable("cumulus_menus.menu_title.minecraft");
     public static final BooleanSupplier MINECRAFT_CONDITION = () -> true;
+    private static Map<ResourceLocation, Menu> MENUS;
+    public static Menu MINECRAFT;
 
-    public static final DeferredHolder<Menu, Menu> MINECRAFT = MENUS.register("minecraft", () -> new Menu(MINECRAFT_ICON, MINECRAFT_NAME, new TitleScreen(true), MINECRAFT_CONDITION));
+    @ApiStatus.Internal
+    public static void init() {
+        var menus = new HashMap<ResourceLocation, Menu>();
+        MINECRAFT = registerVanillaScreen(menus);
+        var event = new RegisterMenuEvent(menus);
+        ModLoader.postEventWrapContainerInModOrder(event);
+        MENUS = ImmutableMap.copyOf(menus);
+    }
+
+    private static Menu registerVanillaScreen(Map<ResourceLocation, Menu> effects) {
+        var vanilla = new Menu(MINECRAFT_ICON, MINECRAFT_NAME, new TitleScreen(true), MINECRAFT_CONDITION);
+        effects.put(ResourceLocation.withDefaultNamespace("minecraft"), vanilla);
+        return vanilla;
+    }
 
     @Nullable
-    public static Menu get(String id) {
-        return Cumulus.MENU_REGISTRY.get(ResourceLocation.withDefaultNamespace(id));
+    public static ResourceLocation getKey(Menu menu) {
+        for (var entry : MENUS.entrySet()) {
+            if (entry.getValue().equals(menu)) return entry.getKey();
+        }
+        return null;
+    }
+
+    public static Menu get(ResourceLocation type) {
+        return MENUS.getOrDefault(type, MINECRAFT);
     }
 
     /**
      * @return A {@link List} of all registered {@link Menu}s.
      */
     public static List<Menu> getMenus() {
-        return Cumulus.MENU_REGISTRY.stream().toList();
+        return List.copyOf(MENUS.values());
     }
 
     /**
      * @return A {@link List} of all {@link Menu}s' {@link Screen}s.
      */
     public static List<Screen> getMenuScreens() {
-        return getMenus().stream().map(Menu::getScreen).collect(Collectors.toList());
+        return getMenus().stream().map(Menu::screen).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/aetherteam/cumulus/api/RegisterMenuEvent.java
+++ b/src/main/java/com/aetherteam/cumulus/api/RegisterMenuEvent.java
@@ -1,0 +1,36 @@
+package com.aetherteam.cumulus.api;
+
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.bus.api.Event;
+import net.neoforged.bus.api.ICancellableEvent;
+import net.neoforged.fml.LogicalSide;
+import net.neoforged.fml.event.IModBusEvent;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.Map;
+
+/**
+ * Allows users to register custom {@link Menu menus} for the title screen.
+ *
+ * <p>These will show up under the "Menu List" button Cumulus adds, allowing for easy swapping between custom main menus.
+ *
+ * <p>This event is not {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.
+ *
+ * <p>This event is fired on the mod-specific event bus, only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ */
+public class RegisterMenuEvent extends Event implements IModBusEvent {
+
+    private final Map<ResourceLocation, Menu> menus;
+
+    @ApiStatus.Internal
+    public RegisterMenuEvent(Map<ResourceLocation, Menu> menus) {
+        this.menus = menus;
+    }
+
+    /**
+     * Registers a new {@link Menu}.
+     */
+    public void register(ResourceLocation menuName, Menu menu) {
+        this.menus.put(menuName, menu);
+    }
+}

--- a/src/main/java/com/aetherteam/cumulus/client/gui/component/MenuSelectionList.java
+++ b/src/main/java/com/aetherteam/cumulus/client/gui/component/MenuSelectionList.java
@@ -62,7 +62,7 @@ public class MenuSelectionList extends ObjectSelectionList<MenuSelectionList.Men
 
         @Override
         public Component getNarration() {
-            return this.menu.getName();
+            return this.menu.name();
         }
 
         @Override
@@ -73,12 +73,12 @@ public class MenuSelectionList extends ObjectSelectionList<MenuSelectionList.Men
             poseStack.popPose();
             RenderSystem.setShaderColor(1, 1, 1, 1);
             poseStack.pushPose();
-            guiGraphics.blit(this.menu.getIcon(), left + ENTRY_PADDING + 1, top + 1, 0, 0, 16, 16, 16, 16);
+            guiGraphics.blit(this.menu.icon(), left + ENTRY_PADDING + 1, top + 1, 0, 0, 16, 16, 16, 16);
             poseStack.popPose();
 
             Font font = this.parent.getFontRenderer();
             int fontWidth = MenuSelectionList.this.getRowWidth() - (ENTRY_PADDING * 2) - 24;
-            List<FormattedCharSequence> lines = font.split(this.menu.getName(), fontWidth);
+            List<FormattedCharSequence> lines = font.split(this.menu.name(), fontWidth);
 
 
             int length = 1;


### PR DESCRIPTION
Hi there!

I want to optionally depend on this mod for the Betweenlands to add the custom screen to it, but with it being a registry that isnt really possible. This is also more of a personal thing, but I dont think this needs to be a registry in the first place. The title screen is client only, and if a mod fails before the game loads the logs will always blame Cumulus as the registry wont be populated. So, I've migrated this to a client event instead. Since events can be conditionally subscribed to, this works a lot better for an optional dependency. This also allows the screen to easily fall back to the default if something goes horribly wrong, and the mod will not be blamed in the process. 

I would have loved to make this resource pack driven instead so no custom code is required, but unfortunately feeding the title screen class into a json is not really something you can do, especially if the ctor has parameters it needs. 

---

I agree to the Contributor License Agreement (CLA).