### PR TITLE
fix: attempt to prevent class loading of client side classes

### DIFF
--- a/common/src/main/resources/cumulus_menus.mixins.json
+++ b/common/src/main/resources/cumulus_menus.mixins.json
@@ -4,12 +4,11 @@
   "package": "com.aetherteam.cumulus.mixin.mixins",
   "refmap": "${mod_id}.refmap.json",
   "compatibilityLevel": "JAVA_18",
-  "mixins": [
+  "mixins": [],
+  "client": [
     "client.MinecraftServerMixin",
     "common.DirectoryLockMixin",
-    "common.accessor.MinecraftServerAccessor"
-  ],
-  "client": [
+    "common.accessor.MinecraftServerAccessor",
     "client.CameraMixin",
     "client.ConnectScreenMixin",
     "client.CreateWorldScreenMixin",

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     },
     "license": "${mod_license}",
     "icon": "${mod_id}.png",
-    "environment": "*",
+    "environment": "client",
     "entrypoints": {
         "main": [
             "com.aetherteam.cumulus.CumulusFabric"


### PR DESCRIPTION
Attempts to fully fix any possibity from occurring where clientside classes are loaded on the server by moving all classes to client side mixins and adjust fabric to be launched only in client environment. Fixes #32


Also sorry wrong branch name... my bad